### PR TITLE
Fix broken `.rrgitignore` reading and log future errors

### DIFF
--- a/rrgit/__init__.py
+++ b/rrgit/__init__.py
@@ -74,11 +74,13 @@ class Config():
         try:
             with open(self.ignore_path, 'r') as f:
                 self.ignore = []
-                for l in f.readlines:
+                for l in f:
                     l = l.rstrip()
                     if l:
                         self.ignore.append(l)
         except Exception as e:
+            if not self.no_warn:
+                error(str(e))
             self.ignore = DEFAULT_IGNORE
         
         self.valid = True


### PR DESCRIPTION
Thanks for this useful tool!

`.rrgitignore` is currently broken because an exception arising from missing parentheses after `readlines` is being caught and silenced.

This change logs the error (to hopefully prevent future problems like this) and simplifies the file line iteration.